### PR TITLE
Remove unnecessary 'compiler_abstraction.h' to get rid of duplicate '…

### DIFF
--- a/source/nRF51ServiceDiscovery.cpp
+++ b/source/nRF51ServiceDiscovery.cpp
@@ -117,7 +117,7 @@ nRF51ServiceDiscovery::progressCharacteristicDiscovery(void)
     /* Iterate through the previously discovered characteristics cached in characteristics[]. */
     while ((state == CHARACTERISTIC_DISCOVERY_ACTIVE) && (characteristicIndex < numCharacteristics)) {
         if ((matchingCharacteristicUUID == UUID::ShortUUIDBytes_t(BLE_UUID_UNKNOWN)) ||
-            ((matchingCharacteristicUUID == characteristics[characteristicIndex].getShortUUID()) &&
+            ((matchingCharacteristicUUID == characteristics[characteristicIndex].getUUID()) &&
              (matchingServiceUUID != UUID::ShortUUIDBytes_t(BLE_UUID_UNKNOWN)))) {
             if (characteristicCallback) {
                 characteristicCallback(&characteristics[characteristicIndex]);

--- a/source/nRF51ServiceDiscovery.cpp
+++ b/source/nRF51ServiceDiscovery.cpp
@@ -154,7 +154,7 @@ nRF51ServiceDiscovery::progressServiceDiscovery(void)
     /* Iterate through the previously discovered services cached in services[]. */
     while ((state == SERVICE_DISCOVERY_ACTIVE) && (serviceIndex < numServices)) {
         if ((matchingServiceUUID == UUID::ShortUUIDBytes_t(BLE_UUID_UNKNOWN)) ||
-            (matchingServiceUUID == services[serviceIndex].getUUID().getShortUUID())) {
+            (matchingServiceUUID == services[serviceIndex].getUUID())) {
 
             if (serviceCallback && (matchingCharacteristicUUID == UUID::ShortUUIDBytes_t(BLE_UUID_UNKNOWN))) {
                 serviceCallback(&services[serviceIndex]);

--- a/source/nordic-sdk/components/drivers_nrf/hal/nrf_delay.c
+++ b/source/nordic-sdk/components/drivers_nrf/hal/nrf_delay.c
@@ -31,7 +31,7 @@
  */
  
 #include <stdio.h> 
-#include "compiler_abstraction.h"
+
 #include "nrf.h"
 #include "nrf_delay.h"
 


### PR DESCRIPTION
The `compiler_abstraction.h` header is unnecessary here because `mbed/libraries/mbed/targets/cmsis/core_cm0.h` already abstracts out the `__ASM` definition.

If the file is included, you get a `warning: "__ASM" redefined` warning.

The specific files are

- `nRF51822/source/nordic-sdk/components/drivers_nrf/hal/compiler_abstraction.h` and
- `mbed/libraries/mbed/targets/cmsis/core_cm0.h`