### PR TITLE
Add S110 SoftDevice compatibility

### DIFF
--- a/source/btle/btle.cpp
+++ b/source/btle/btle.cpp
@@ -113,12 +113,18 @@ static void btle_handler(ble_evt_t *p_ble_evt)
     switch (p_ble_evt->header.evt_id) {
         case BLE_GAP_EVT_CONNECTED: {
             Gap::Handle_t handle = p_ble_evt->evt.gap_evt.conn_handle;
+#if defined(MCU_NORDIC_16K_S110) || defined(MCU_NORDIC_32K_S110)
+            /* Only peripheral role is supported by S110 */
+            Gap::Role_t role = Gap::PERIPHERAL;
+#else
+            Gap::Role_t role = static_cast<Gap::Role_t>(p_ble_evt->evt.gap_evt.params.connected.role);
+#endif
             nRF5xGap::getInstance().setConnectionHandle(handle);
             const Gap::ConnectionParams_t *params = reinterpret_cast<Gap::ConnectionParams_t *>(&(p_ble_evt->evt.gap_evt.params.connected.conn_params));
             const ble_gap_addr_t *peer = &p_ble_evt->evt.gap_evt.params.connected.peer_addr;
             const ble_gap_addr_t *own  = &p_ble_evt->evt.gap_evt.params.connected.own_addr;
             nRF5xGap::getInstance().processConnectionEvent(handle,
-                                                           static_cast<Gap::Role_t>(p_ble_evt->evt.gap_evt.params.connected.role),
+                                                           role,
                                                            static_cast<Gap::AddressType_t>(peer->addr_type), peer->addr,
                                                            static_cast<Gap::AddressType_t>(own->addr_type),  own->addr,
                                                            params);

--- a/source/nordic-sdk/components/softdevice/s130/include/ble_gap.h
+++ b/source/nordic-sdk/components/softdevice/s130/include/ble_gap.h
@@ -547,7 +547,9 @@ typedef struct
 {
   ble_gap_addr_t        peer_addr;              /**< Bluetooth address of the peer device. */
   ble_gap_addr_t        own_addr;               /**< Bluetooth address of the local device used during connection setup. */
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
   uint8_t               role;                   /**< BLE role for this connection, see @ref BLE_GAP_ROLES */
+#endif
   uint8_t               irk_match :1;           /**< If 1, peer device's address resolved using an IRK. */
   uint8_t               irk_match_idx  :7;      /**< Index in IRK list where the address was matched. */
   ble_gap_conn_params_t conn_params;            /**< GAP Connection Parameters. */


### PR DESCRIPTION
This humble change adds backward-compatibility for S110 to the nRF51822 API. It assumes that the build system will defines either *MCU_NORDIC_16K_S110* or *MCU_NORDIC_32K_S110* when S110 is enabled instead of the default S130.

Currently, the only major difference between S110 and S130 headers is the added "role" parameter in the ble_gap_evt_connected_t structure, sent by the softdevice after a connection. These patches handle this case.

Please note that this is only for build compatibility. Applications built for S110 will work, but their behaviour when attempting to use S130 features, such as GAP scanning, is undefined. This will need some additional work to return a clean "not implemented" value.